### PR TITLE
Fix setting bounds (non-canonical) untagged capabilities

### DIFF
--- a/cheri_compressed_cap_common.h
+++ b/cheri_compressed_cap_common.h
@@ -840,13 +840,16 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
      */
     const _cc_addr_t cursor = cap->_cr_cursor;
 #ifndef CC_IS_MORELLO
-    _cc_debug_assert(((cap->_cr_top - cap->cr_base) >> _CC_ADDR_WIDTH) <= 1 && "Length must be smaller than 1 << 65");
-    _cc_debug_assert((req_top >> _CC_ADDR_WIDTH) <= 1 && "New top must be smaller than 1 << 65");
-    _cc_debug_assert(req_base >= cap->cr_base && "Cannot decrease base");
-    _cc_debug_assert(req_top <= cap->_cr_top && "Cannot increase top");
-    assert((cursor < cap->_cr_top || (cursor == cap->_cr_top && req_base == cap->_cr_top && req_base == req_top)) &&
-           "Must be used on inbounds caps or request zero-length cap at top");
-    assert((cursor >= cap->cr_base) && "Must be used on inbounds caps");
+    if (cap->cr_tag) {
+        _cc_debug_assert(((cap->_cr_top - cap->cr_base) >> _CC_ADDR_WIDTH) <= 1 &&
+                         "Length must be smaller than 1 << 65");
+        _cc_debug_assert((req_top >> _CC_ADDR_WIDTH) <= 1 && "New top must be smaller than 1 << 65");
+        _cc_debug_assert(req_base >= cap->cr_base && "Cannot decrease base");
+        _cc_debug_assert(req_top <= cap->_cr_top && "Cannot increase top");
+        assert((cursor < cap->_cr_top || (cursor == cap->_cr_top && req_base == cap->_cr_top && req_base == req_top)) &&
+               "Must be used on inbounds caps or request zero-length cap at top");
+        assert((cursor >= cap->cr_base) && "Must be used on inbounds caps");
+    }
 #endif
     _CC_STATIC_ASSERT(_CC_EXP_LOW_WIDTH == 3, "expected 3 bits to be used by");  // expected 3 bits to
     _CC_STATIC_ASSERT(_CC_EXP_HIGH_WIDTH == 3, "expected 3 bits to be used by"); // expected 3 bits to

--- a/cheri_compressed_cap_common.h
+++ b/cheri_compressed_cap_common.h
@@ -876,9 +876,14 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
                          "Was inexact, but neither base nor top different?");
     }
 
-    _cc_debug_assert(new_top >= new_base);
-    _cc_debug_assert((!cap->cr_tag || _cc_N(get_reserved)(cap) == 0) &&
-                     "Unknown reserved bits set in tagged capability");
+    if (cap->cr_tag) {
+        // For invalid inputs, new_top could have been larger than max_top and if it is sufficiently larger, it
+        // will be truncated to zero, so we can only assert that we get top > base for tagged, valid inputs.
+        // See https://github.com/CTSRD-CHERI/sail-cheri-riscv/pull/36 for a decoding change that guarantees
+        // this invariant for any input.
+        _cc_debug_assert(new_top >= new_base);
+        _cc_debug_assert(_cc_N(get_reserved)(cap) == 0 && "Unknown reserved bits set in tagged capability");
+    }
     cap->_cr_cursor = req_base;
     cap->cr_base = new_base;
     cap->_cr_top = new_top;

--- a/cheri_compressed_cap_common.h
+++ b/cheri_compressed_cap_common.h
@@ -829,8 +829,7 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
     bool from_large = !_cc_N(cap_bounds_uses_value)(cap);
 #else
     // Morello allows setbounds to do weird things and will just result in untagged results
-    _cc_debug_assert((cap->cr_tag) && "Cannot be used on untagged capabilities");
-    _cc_debug_assert((!_cc_N(is_cap_sealed)(cap)) && "Cannot be used on sealed capabilities");
+    _cc_debug_assert(!(cap->cr_tag && _cc_N(is_cap_sealed)(cap)) && "Cannot be used on tagged sealed capabilities");
 #endif
     _cc_debug_assert(req_base <= req_top && "Cannot invert base and top");
     /*
@@ -838,7 +837,6 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
      * memory addresses to be wider than requested so it is
      * representable.
      */
-    const _cc_addr_t cursor = cap->_cr_cursor;
 #ifndef CC_IS_MORELLO
     if (cap->cr_tag) {
         _cc_debug_assert(((cap->_cr_top - cap->cr_base) >> _CC_ADDR_WIDTH) <= 1 &&
@@ -846,9 +844,10 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
         _cc_debug_assert((req_top >> _CC_ADDR_WIDTH) <= 1 && "New top must be smaller than 1 << 65");
         _cc_debug_assert(req_base >= cap->cr_base && "Cannot decrease base");
         _cc_debug_assert(req_top <= cap->_cr_top && "Cannot increase top");
-        assert((cursor < cap->_cr_top || (cursor == cap->_cr_top && req_base == cap->_cr_top && req_base == req_top)) &&
+        assert((cap->_cr_cursor < cap->_cr_top ||
+                (cap->_cr_cursor == cap->_cr_top && req_base == cap->_cr_top && req_base == req_top)) &&
                "Must be used on inbounds caps or request zero-length cap at top");
-        assert((cursor >= cap->cr_base) && "Must be used on inbounds caps");
+        assert((cap->_cr_cursor >= cap->cr_base) && "Must be used on inbounds caps");
     }
 #endif
     _CC_STATIC_ASSERT(_CC_EXP_LOW_WIDTH == 3, "expected 3 bits to be used by");  // expected 3 bits to
@@ -860,7 +859,7 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
     const _cc_addr_t pesbt = _CC_ENCODE_FIELD(0, UPERMS) | _CC_ENCODE_FIELD(0, HWPERMS) |
                              _CC_ENCODE_FIELD(_CC_N(OTYPE_UNSEALED), OTYPE) | _CC_ENCODE_FIELD(new_ebt, EBT);
     _cc_cap_t new_cap;
-    _cc_N(decompress_raw)(pesbt, cursor, cap->cr_tag, &new_cap);
+    _cc_N(decompress_raw)(pesbt, req_base, cap->cr_tag, &new_cap);
     _cc_addr_t new_base = new_cap.cr_base;
     _cc_length_t new_top = new_cap._cr_top;
 
@@ -880,6 +879,7 @@ static inline bool _cc_N(setbounds_impl)(_cc_cap_t* cap, _cc_addr_t req_base, _c
     _cc_debug_assert(new_top >= new_base);
     _cc_debug_assert((!cap->cr_tag || _cc_N(get_reserved)(cap) == 0) &&
                      "Unknown reserved bits set in tagged capability");
+    cap->_cr_cursor = req_base;
     cap->cr_base = new_base;
     cap->_cr_top = new_top;
     cap->cr_exp = new_cap.cr_exp;

--- a/test/sail_wrapper_128m.c
+++ b/test/sail_wrapper_128m.c
@@ -87,3 +87,7 @@ struct cc128m_bounds_bits sail_extract_bounds_bits_128m(uint64_t pesbt) {
 }
 uint64_t sail_compress_128m_raw(const cc128m_cap_t* csp) { return sail_compress_common_raw(csp); }
 uint64_t sail_compress_128m_mem(const cc128m_cap_t* csp) { return sail_compress_common_mem(csp); }
+
+bool sail_setbounds_128m(cc128m_cap_t* cap, cc128m_addr_t req_base, cc128m_length_t req_top) {
+    abort(); // TODO: call sailgen_CapSetBounds();
+}


### PR DESCRIPTION
This was found by the fuzzer since it triggered an assertion, now it
matches the sail outputs.
When calling decompress_raw we have to use req_base and not the current
address to infer the bounds. This did not matter previously since we only
called the function on in-bounds caps, so the result was the same, but now
that we allow out-of-bounds untagged values, we have to use req_base
instead and set the address to req_base.
