### PR TITLE
Update the set_permissions operation for RVY.

### DIFF
--- a/cheri_compressed_cap_128r.h
+++ b/cheri_compressed_cap_128r.h
@@ -200,6 +200,7 @@ static inline bool _cc_N(set_permissions)(_cc_cap_t* cap, _cc_addr_t permissions
                         "invalid permissions");
     // TODO: legalize permissions or reject invalid requests
     _cc_addr_t sw_perms = (permissions >> _CC_N(UPERMS_SHFT)) & _CC_N(UPERMS_ALL);
+    _cc_mode mode = (_cc_mode)_CC_EXTRACT_FIELD(cap->cr_pesbt, MODE);
     // See "Encoding of architectural permissions for MXLEN=64" in the spec
     _cc_addr_t result = 0;
     if (permissions & CC128R_PERM_CAPABILITY)
@@ -224,6 +225,10 @@ static inline bool _cc_N(set_permissions)(_cc_cap_t* cap, _cc_addr_t permissions
     }
     cap->cr_pesbt = _CC_DEPOSIT_FIELD(cap->cr_pesbt, result, AP);
     cap->cr_pesbt = _CC_DEPOSIT_FIELD(cap->cr_pesbt, sw_perms, SDP);
+    if ((permissions & CC128R_PERM_EXECUTE) == 0 && mode == _CC_N(MODE_INT)) {
+        cap->cr_pesbt = _CC_DEPOSIT_FIELD(cap->cr_pesbt, (unsigned)_CC_N(MODE_CAP), MODE);
+        return false;
+    }
     return true; // all permissions are representable
 }
 

--- a/test/simple_test_common.cpp
+++ b/test/simple_test_common.cpp
@@ -236,6 +236,10 @@ TEST_CASE("set zero and almighty permissions", "[perms]") {
     CHECK(max_cap.all_permissions() > 1);
     CHECK((max_cap.all_permissions() & _CC_N(PERM_SW_ALL)) == _CC_N(PERM_SW_ALL));
     CHECK((max_cap.all_permissions() & _CC_N(PERMS_MASK)) == _CC_N(PERMS_MASK));
+#ifndef TEST_CC_IS_MORELLO
+    // Clearing permission may also modify mode bit, preemptively set cap mode
+    CHECK(_cc_N(set_execution_mode)(&max_cap, _CC_N(MODE_CAP)) == true);
+#endif
     // Should be able to clear all permissions
     CHECK(_cc_N(set_permissions)(&max_cap, 0) == true);
     CHECK(max_cap.has_permissions(_CC_N(PERM_EXECUTE)) == false);

--- a/test/simple_test_common.cpp
+++ b/test/simple_test_common.cpp
@@ -334,6 +334,14 @@ TEST_CASE("test mode API", "[perms]") {
             CHECK(_cc_N(get_execution_mode)(&cap) == _CC_N(MODE_CAP));
         }
     }
+    if (!is_isa_v9) {
+        // For the RISC-V standard version, clearing PERM_EXECUTE will enter MODE_CAP
+        auto cap = max_cap;
+        CHECK(_cc_N(set_execution_mode)(&cap, _CC_N(MODE_INT)));
+        CHECK(_cc_N(get_execution_mode)(&cap) == _CC_N(MODE_INT));
+        CHECK(_cc_N(set_permissions)(&cap, _CC_N(PERMS_MASK) & ~_CC_N(PERM_EXECUTE)) == false);
+        CHECK(_cc_N(get_execution_mode)(&cap) == _CC_N(MODE_CAP));
+    }
 }
 
 TEST_CASE("removing ASR should not throw", "[perms]") {


### PR DESCRIPTION
# PR for CI

The mode bit is squashed to 0 if the resulting capability does not have PERM_EXECUTE.
This is consistent with the latest RVY specification. Note that explicitly setting the mode on capabilities without PERM_EXECUTE continues to be forbidden, regardless of the mode value being updated.